### PR TITLE
fix(localforageObservable): Correctly set crossTabChangeDetection

### DIFF
--- a/lib/localforageObservable.js
+++ b/lib/localforageObservable.js
@@ -111,7 +111,7 @@ function configObservables(options) {
         obs.crossTabObserver = null;
     }
 
-    obs = options.crossTabChangeDetection;
+    obs.crossTabChangeDetection = options.crossTabChangeDetection;
 }
 
 export function newObservable(options) {


### PR DESCRIPTION
The `crossTabChangeDetection` option is used to determine whether to [detect changes](https://github.com/localForage/localForage-observable/blob/master/lib/localforageObservable.js#L26).

This option was not being saved to the local instance object correctly, so cross tab change detection did not work as expected. The only way to set `detectChanges` to `true` was to add a local observer with `changeDetection` enabled.

With this change, the `crossTabChangeDetection` option should work as expected.