### PR TITLE
Update NPM registry data

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "observable"
   ],
   "author": "Thodoris Greasidis",
-  "licence": "Apache-2.0",
+  "license": "Apache-2.0",
   "bugs": {
-    "url": "http://github.com/thgreasi/localForage-observable/issues"
+    "url": "https://github.com/thgreasi/localForage-observable/issues"
   },
   "devDependencies": {
     "@reactivex/rxjs": "^5.0.0-beta.7",


### PR DESCRIPTION
Hello - I noticed that the NPM registry does not list a license for this project, because there is a small typo in `package.json`. This PR fixes the typo, and also updates one URL that was still using HTTP instead of HTTPS.